### PR TITLE
Missing dependencies

### DIFF
--- a/info.rkt
+++ b/info.rkt
@@ -20,6 +20,8 @@
                "txexpr"
                "gregor-lib"
                "frog"
+               "lazy" ; for home page sample
+               "datalog" ; for home page sample
                ("s3-sync" #:version "1.9")))
 
 (define pkg-desc "Sources for http://racket-lang.org")


### PR DESCRIPTION
Working from a `base` installation, I needed to manually install `lazy` and `datalog` to build the website, because of the code samples on the home page.