### PR TITLE
Fix x-height of monospaced font

### DIFF
--- a/www/css/styles.css.pp
+++ b/www/css/styles.css.pp
@@ -110,7 +110,7 @@ top-section {
     opacity: .3;
 }
 
-.lang > .inner tt {
+.lang > .inner :first-child tt {
     font-size: 85%;
     white-space: pre;
 }


### PR DESCRIPTION
The monospaced font didn’t match the x-height of the surrounding text.

Before:

![before](https://cloud.githubusercontent.com/assets/586813/21466789/9596f2ae-c9a3-11e6-87b6-70ec5f82bff3.png)

After:

![after](https://cloud.githubusercontent.com/assets/586813/21466795/a56a2ee4-c9a3-11e6-9585-70524d2c88d1.png)
