### PR TITLE
Changed link to H2DP from https to http

### DIFF
--- a/www/index.html.pm
+++ b/www/index.html.pm
@@ -228,7 +228,7 @@ Community
 Books
 
 
-◊link["https://www.htdp.org/"]{How to Design Programs}
+◊link["http://www.htdp.org/"]{How to Design Programs}
 A principled approach to programming.
 
 


### PR DESCRIPTION
The HTTPS link goes to the Pyret language homepage (presumably hosted on the same server), instead of the H2DP homepage