### PR TITLE
change link to 'available langs'

### DIFF
--- a/www/index.html.pm
+++ b/www/index.html.pm
@@ -81,7 +81,7 @@
 }
 }
 
-◊special-section[#:class "one-column-body-text" #:id "pull-quote"]{Racket is a ◊link["https://docs.racket-lang.org/quick/index.html"]{general-purpose programming language} as well as the ◊link["https://www.ccs.neu.edu/home/matthias/manifesto/"]{world's first ecosystem} for developing and deploying new languages. Make your ◊link["https://docs.racket-lang.org/guide/languages.html"]{dream language}, or use one of the dozens ◊link["https://pkgs.racket-lang.org/"]{already available}, including these —}
+◊special-section[#:class "one-column-body-text" #:id "pull-quote"]{Racket is a ◊link["https://docs.racket-lang.org/quick/index.html"]{general-purpose programming language} as well as the ◊link["https://www.ccs.neu.edu/home/matthias/manifesto/"]{world's first ecosystem} for developing and deploying new languages. Make your ◊link["https://docs.racket-lang.org/guide/languages.html"]{dream language}, or use one of the dozens ◊link["http://docs.racket-lang.org/search/index.html?q=H%3A"]{already available}, including these —}
 
 
 ◊special-section{


### PR DESCRIPTION
Old link: the package server

New link: the search page, with query `H:`, which lists every module
 registered through `defmodulelang` (includes main distro & packages)