### PR TITLE
say 'python' in the 'pygments not installed' error message

### DIFF
--- a/blog/all.rkt
+++ b/blog/all.rkt
@@ -16,7 +16,7 @@
 (define css-dir (simplify-path (build-path blog-dir "css/")))
 
 (unless (system "python -c 'import pygments'")
-  (error "pygments required to preserve doc links for code on the blog"))
+  (error 'python "pygments required to preserve doc links for code on the blog"))
 
 (define v (all-tools))
 ;; frog rebuild: generates blog html


### PR DESCRIPTION
It's not much, but it's a hint that the reason your `all.rkt`
raised an exception is due to the `python` system command and
nothing to do with your Racket