### PR TITLE
embed the racket world map

### DIFF
--- a/www/team.html.pm
+++ b/www/team.html.pm
@@ -14,6 +14,14 @@
 
 
 ◊section{
+◊div{Racket World Map}
+
+◊iframe[#:src "https://www.google.com/maps/d/u/0/embed?mid=1i3zN11e_6te5ytduAiv1cidrIi4" #:width "640" #:height "480" #:align "top"]
+}
+
+
+
+◊section{
 ◊div{Recognized Contributors
 
 ◊p[#:style "font-size: 80%;margin-top: 1rem;color: gray;width:80%;line-height:1.5"]{Racket is developed by a broad community of contributors. The following people have earned special recognition for their work.}}


### PR DESCRIPTION
Hi, I tried to embed a map in the PLT page, as suggested in https://github.com/racket/racket-lang-org/pull/61

This current attempt doesn't seem to work --- I ran `www/all.rkt` and then opened the generated `plt.html` in my browser and got a blank frame (see next comment).

I'm posting this PR in case anyone has suggestions, and so I don't forget to try this again soon!