### PR TITLE
blog typo: reduce est. time for raco setup

### DIFF
--- a/blog/_src/posts/2017-09-27-tutorial-contributing-to-racket.md
+++ b/blog/_src/posts/2017-09-27-tutorial-contributing-to-racket.md
@@ -190,7 +190,7 @@ $ ./racket/bin/raco test -l tests/racket/test
 ```
 <br/>
 
-> Estimated time for `setup`: 1-4 hours
+> Estimated time for `setup`: 0-3 hours
 
 > Estimated time for `test`: 1 hour
 


### PR DESCRIPTION
A `raco setup` is probably not going to take longer than a `make`

- - - 

This is inspired by comments by @odanoburu in https://github.com/racket/racket/pull/2181 .

Let me know if anyone has ideas how to re-word the blog post to make sure people don't get the idea that it'll take 8 hours to build racket on an old machine. I couldn't think of anything.