### PR TITLE
fix broken link in home page

### DIFF
--- a/www/index.html.pm
+++ b/www/index.html.pm
@@ -79,7 +79,7 @@
 }
 }
 
-◊special-section[#:class "one-column-body-text" #:id "pull-quote"]{Racket is a ◊link["https://docs.racket-lang.org/quick/index.html"]{general-purpose programming language} as well as the ◊link["https://www.ccs.neu.edu/home/matthias/manifesto/"]{world's first ecosystem} for language-oriented programming. Make your ◊link["https://docs.racket-lang.org/guide/languages.html"]{dream language}, or use one of the dozens ◊link["http://docs.racket-lang.org/search/index.html?q=H%3A"]{already available}, including these —}
+◊special-section[#:class "one-column-body-text" #:id "pull-quote"]{Racket is a ◊link["https://docs.racket-lang.org/quick/index.html"]{general-purpose programming language} as well as the ◊link["http://felleisen.org/matthias/manifesto/"]{world's first ecosystem} for language-oriented programming. Make your ◊link["https://docs.racket-lang.org/guide/languages.html"]{dream language}, or use one of the dozens ◊link["http://docs.racket-lang.org/search/index.html?q=H%3A"]{already available}, including these —}
 
 
 ◊special-section{


### PR DESCRIPTION
Fixes the link to Racket Manifesto in the homepage's language description text.