### PR TITLE
Racket 7.4 announcement: backquote double dashes to avoid conversion to em-dash

### DIFF
--- a/blog/_src/posts/2019-08-08-racket-v7-4.md
+++ b/blog/_src/posts/2019-08-08-racket-v7-4.md
@@ -33,7 +33,7 @@ by reporting any problems that you find.
   Racket's compiler will fold a call of `real->single-flonum` on a
   literal number to a constant single-flonum value.
 
-* New compilation flags including --disable-generations and --enable-ubsan
+* New compilation flags including `--disable-generations` and `--enable-ubsan`
   provide better support for alternative
   architectures.
 


### PR DESCRIPTION
Frog (or more specifically, [greghendershott/markdown](https://github.com/greghendershott/markdown)) automatically converts `--` to em-dashes; we don't want this for command-line arguments. Quote them to avoid this behavior.