### PR TITLE
Make it readable

### DIFF
--- a/blog/_src/posts/2009-05-24-explicit-renaming-macros-implicitly.md
+++ b/blog/_src/posts/2009-05-24-explicit-renaming-macros-implicitly.md
@@ -88,7 +88,7 @@ With this utility defined, the above macro becomes much easier to deal with:
              (body  (cddr exp)))
          `((,(syntax lambda) ,vars ,@body)
            ,@inits)))))
- ```
+```
 
  ...and this is almost identical to the explicit renaming version of the macro; for example, compare it with the sample code in the [MIT-Scheme manual](http://groups.csail.mit.edu/mac/projects/scheme/documentation/scheme_3.html#SEC49).  The only change is that `(rename 'lambda)` is replaced with `(syntax lambda)`.
 


### PR DESCRIPTION
https://blog.racket-lang.org/2009/05/explicit-renaming-macros-implicitly.html is not formatted as intended due to an extra space. While this formats as intended in several Markdown parsers, it does not in Racket's implementation. Fixing the source code itself is probably going to be easier than fixing the parser.