### PR TITLE
blog: update type tailoring link

### DIFF
--- a/blog/_src/posts/2017-04-18-type-tailoring.md
+++ b/blog/_src/posts/2017-04-18-type-tailoring.md
@@ -304,7 +304,7 @@ as well as syntax for defining new tailorings.
 For further reading on type tailoring, and a sketch of how to prove the
  soundness of a tailoring, we have a draft paper:
 
-- [`http://www.ccs.neu.edu/home/types/resources/type-tailoring.pdf`][2]
+- <http://hdl.handle.net/2047/D20324606>
 
 The draft also reports on a small evaluation of our tailored
  `regexp-match`[racket] on existing code.


### PR DESCRIPTION
The type tailoring draft now exists as on the Northeastern DRS as a tech
report (NU-CCIS-TR-2019-002), so point there instead of the pdf on my
homepage