### PR TITLE
Don't compile pollen.rkt to avoid zo version mismatch errors.

### DIFF
--- a/rcon/2019/info.rkt
+++ b/rcon/2019/info.rkt
@@ -1,0 +1,3 @@
+#lang info
+
+(define compile-omit-paths '("pollen.rkt"))


### PR DESCRIPTION
Fixes #110.