### PR TITLE
Fix serverracket.com not redirecting HTTP->HTTPS

### DIFF
--- a/www/books.html.pm
+++ b/www/books.html.pm
@@ -28,7 +28,7 @@ Learn to program with Racket, one game at a time.
 Make your own programming languages with Racket.
 
 
-◊link["http://serverracket.com"]{Server: Racket}
+◊link["https://serverracket.com"]{Server: Racket}
 Develop a web application with Racket.
 
 

--- a/www/index.html.pm
+++ b/www/index.html.pm
@@ -249,7 +249,7 @@ Learn to program with Racket, one game at a time.
 ◊link["https://beautifulracket.com/"]{Beautiful Racket}
 Make your own programming languages with Racket.
 
-◊link["http://serverracket.com"]{Server: Racket}
+◊link["https://serverracket.com"]{Server: Racket}
 Develop a web application with Racket.
 
 


### PR DESCRIPTION
I get 404 on both Firefox and Chromium if I try to access the URL on the frontpage, seemingly because the webpage does not redirect HTTP to HTTPS.