### PR TITLE
corrected url for Carl Eastlund

### DIFF
--- a/www/team.html.pm
+++ b/www/team.html.pm
@@ -64,7 +64,7 @@
 
 ◊link["https://www.cs.umd.edu/~sstrickl/"]{T. Stephen Strickland}
 
-◊link["www.ccs.neu.edu/home/cce/"]{Carl Eastlund}
+◊link["https://www.ccs.neu.edu/home/cce/"]{Carl Eastlund}
 
 ◊link["http://people.seas.harvard.edu/~chrdimo/"]{Christos Dimoulas}
 


### PR DESCRIPTION
now https://www.ccs.neu.edu/home/cce/  was previously rendering as https://racket-lang.org/www.ccs.neu.edu/home/cce/