### PR TITLE
Fixes #120: revamp JavaScript on the download page

### DIFF
--- a/download/data.rkt
+++ b/download/data.rkt
@@ -24,7 +24,7 @@
                  [(equal? cpu "ppc") "PPC"]
                  [(equal? cpu "i386") "Intel 32-bit"]
                  [(equal? cpu "x86_64") "Intel 64-bit"]
-                 [else (error "unregonized cpu!")])))]
+                 [else (error "unrecognized cpu!")])))]
     ["(ppc|68k)-mac-classic" "Macintosh Classic (\\1)"]
     ["(ppc|i386)-darwin"
      ,(λ (_ cpu)

--- a/download/download-pages.rkt
+++ b/download/download-pages.rkt
@@ -401,9 +401,6 @@ var elem = null;
                         'variant (installer-variant i)
                         'suffix (installer-suffix i))))
                (hash 'platform platform
-                      ;; it doesn't make much sense to use the-regular-variant
-                      ;; to represent the whole platform, but this is what
-                      ;; the original code does, so we will live with it for now
                      'platformName (platform->name platform distname)
                      'installers installers)))))
 

--- a/download/util.rkt
+++ b/download/util.rkt
@@ -1,0 +1,10 @@
+#lang racket/base
+
+(provide get-human-size)
+
+(define (get-human-size size)
+  (define mb (/ size (* 1024 1024)))
+  (if (< mb 10)
+      (let-values ([(q r) (quotient/remainder (round (* mb 10)) 10)])
+        (format "~a.~aM" q r))
+      (format "~aM" (round mb))))


### PR DESCRIPTION
This PR fixes three bugs:
- Remove an extra "Variant" widget.
- Remove redundant "Platform" options
- Add extension information to variants

Additionally, it replaces the current implementation to a declarative approach
similar to big-bang / React framework. The current approach is _extremely_
complicated due to its imperative nature, generating multiple selection widgets,
embedding several information in non-standard attributes of DOM elements,
and showing/hiding them via JS. This is very error prone due to multiple levels
of the selection widgets, and how the number of levels is dynamic. Additionally,
it is very difficult to modify this page.

The new approach is similar to big-bang. We supply the framework the initial
state and the toDraw function, which constructs the DOM tree based on the input
state. Each DOM element can have a handler (such as onclick) which will
transition the current state into the next state. This makes it much easier to
reason about it.