### PR TITLE
avoid certificate error on htdp links

### DIFF
--- a/www/books.html.pm
+++ b/www/books.html.pm
@@ -16,7 +16,7 @@
 ◊section{
 Books
 
-◊link["https://www.htdp.org/"]{How to Design Programs}
+◊link["https://htdp.org/"]{How to Design Programs}
 A principled approach to programming.
 
 

--- a/www/index.html.pm
+++ b/www/index.html.pm
@@ -262,7 +262,7 @@ Develop a web application with Racket.
 ◊section{
 Education
 
-◊link["https://www.htdp.org/"]{How to Design Programs}
+◊link["https://htdp.org/"]{How to Design Programs}
 A principled approach to programming.
 
 


### PR DESCRIPTION
short term fix to resolve issue where www.htdp.org triggers a certificate error on safari and chrome #125