### PR TITLE
Wip 2nd suggestions

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ To build:
 
 * The simplest way to build the whole site is with 
 
+  [the below command requires you to first install the racket-lang-org directory as a package]
+
   racket -l- racket-lang-org/sync --save-temps --render-locally Web ; open Web/www/index.html
 
   This renders the site in some temp directory and then moves the directory

--- a/sync.rkt
+++ b/sync.rkt
@@ -137,7 +137,7 @@
       (delete-directory/files render-locally?))
     (define tmp-src (build-path tmp-dir "generated"))
     (define local-dest render-locally?)
-    (rename-file-or-directory tmp-src local-dest #t)
+    (copy-directory/files tmp-src local-dest #:preserve-links? #t)
 
     ;; generate and move code into place
     #;

--- a/www/css/styles.css.pp
+++ b/www/css/styles.css.pp
@@ -505,6 +505,10 @@ a, a:hover {
   transition: color 0.2s;
 }
 
+langwww {
+  color: rgb(115,115,115);
+  font-weight: bold;
+}
 
 .langwww {
     ~height: 11.5rem;

--- a/www/index.html.pm
+++ b/www/index.html.pm
@@ -190,7 +190,7 @@ Newcomers describe the on-line Racket community as extremely ◊strong{friendly 
 ◊langwww["#lang typed/racket" #:id "lang3"]{
 ◊pre{;; Using higher-order occurrence typing
 (◊docs{define-type} SrN (◊docs{U} ◊docs{String} ◊docs{Number}))
-(◊docs{:} tog ((◊docs{Listof} SrN) -> ◊docs{String})
+(◊docs{:} tog ((◊docs{Listof} SrN) -> ◊docs{String}))
 (◊docs{define} (tog l)
   (◊docs{apply} ◊docs{string-append}
          (◊docs{filter} ◊docs{string?} l)))


### PR DESCRIPTION
I have made separate commit of each suggested change.

The `#lang typed/racket` example on the front page doesn't run as-is due to a missing parentheses, the fix is provided in one of the commits.

To get the build process working on my machine, I had to replace `rename-file-or-directory` with `copy-directory/files` since the former doesn't work if `/var/tmp` is on a different partition.

Feel free to pick any commits you think are useful. 