### PR TITLE
Fix url for Server: Racket book

### DIFF
--- a/www/books.html.pm
+++ b/www/books.html.pm
@@ -22,7 +22,7 @@ An introduction to computer science using Scheme.
 ◊link["https://beautifulracket.com/"]{Beautiful Racket}
 Make your own programming languages with Racket.
 
-◊link["http://serverracket.com"]{Server: Racket}
+◊link["https://serverracket.com"]{Server: Racket}
 Develop a web application with Racket.
 
 ◊link["https://cs.brown.edu/~sk/Publications/Books/ProgLangs/2007-04-26/"]{Programming Languages: 

--- a/www/index.html.pm
+++ b/www/index.html.pm
@@ -472,7 +472,7 @@ ancestor(A, B)?}}}
       ◊link["https://beautifulracket.com/"]{Beautiful Racket}
       Make your own programming languages with Racket.
 
-      ◊link["http://serverracket.com"]{Server: Racket}
+      ◊link["https://serverracket.com"]{Server: Racket}
       Develop a web application with Racket.
 
       ◊link["books.html"]{All Racket Books}}}


### PR DESCRIPTION
In both the home and `/books` pages, the rendered link for `Server: Racket` book fails to resolve because of a missing protocol in the url (`serverracket.com` instead of `https://serverracket.com`).