### PR TITLE
corrected case VIM to Vim

### DIFF
--- a/www/index.html.pm
+++ b/www/index.html.pm
@@ -149,7 +149,7 @@ Racket comes with support for major editors. The main bundle includes an innovat
 ◊doclink["drracket"]{DrRacket Guide}
 ◊doclink["drracket-tools"]{DrRacket Tools}
 ◊link["https://docs.racket-lang.org/guide/Emacs.html"]{Emacs Integration}
-◊link["https://docs.racket-lang.org/guide/Vim.html"]{VIM Integration}
+◊link["https://docs.racket-lang.org/guide/Vim.html"]{Vim Integration}
 }
 }}
 


### PR DESCRIPTION
The accepted form is Vim see https://www.vim.org