### PR TITLE
Use Racket on macOS Big Sur 11.1 or above

### DIFF
--- a/download/download-pages.rkt
+++ b/download/download-pages.rkt
@@ -114,11 +114,13 @@
                       @pre:installers{snapshot build}.}}
            null)
       @(cond
-         [(equal? version version-before-m1-support)
+         [(version<=? version version-before-m1-support)
           @div[id: "m1_mac_explain"
                style: note-style]{
                @div{@b{M1 Mac users:}}
-               @list{Try a 64-bit ARM build from one of the @pre:installers{snapshot sites}.}}]
+               @list{The latest version of Racket supports Apple Silicon directly.
+
+               For version @version, the Mac OS (Intel 64-bit) variant requires macOS Big Sur 11.1 or above.}}]
          [(version<? version-before-m1-support version)
           @div[id: "m1_mac_explain"
                style: note-style]{


### PR DESCRIPTION
It's easier to point the students using Mac M1 to a fixed stable version such as 8.1 or 7.9. For this reason, mentioning the snapshot builds creates extra confusion when the particular build happens to contain other bugs.

As Racket works on Mac M1 with macOS 11.1 (or above) but not macOS 11.0, explain that the user may need to upgrade their OS.
