### PR TITLE
freenode -> libera.chat

### DIFF
--- a/blog/_src/posts/2017-09-27-tutorial-contributing-to-racket.md
+++ b/blog/_src/posts/2017-09-27-tutorial-contributing-to-racket.md
@@ -35,7 +35,7 @@ To help streamline the process for potential contributors,
 
 If you have any trouble following along, ask for help via
  [email](https://groups.google.com/forum/#!forum/racket-users),
- [IRC](https://botbot.me/freenode/racket/),
+ [IRC](https://racket-lang.org/community.html),
  and/or [Slack](http://racket-slack.herokuapp.com/).
 
 > For a Git crash course, see: <http://rogerdudler.github.io/git-guide/>

--- a/www/index.html.pm
+++ b/www/index.html.pm
@@ -444,7 +444,7 @@ ancestor(A, B)?}}}
 
       ◊link["https://discord.gg/6Zq8sH5"]{Racket Discord}
 
-      ◊link["https://webchat.freenode.net/#racket"]{#racket IRC} on freenode.net
+      ◊link["https://kiwiirc.com/nextclient/irc.libera.chat/#racket"]{#racket IRC} on libera.chat
 
       ◊link["https://racket.slack.com/"]{Slack channel} (Visit ◊link["http://racket-slack.herokuapp.com/"]{this link} to sign up)
 

--- a/www/irc.rkt
+++ b/www/irc.rkt
@@ -6,7 +6,7 @@
          irc-quick)
 
 (define webchat-link
-  "https://webchat.freenode.net?channels=racket&uio=OT10cnVlJjExPTIzNg6b")
+  "https://kiwiirc.com/nextclient/irc.libera.chat/#racket")
 
 (define irc-chat
   @page[#:site www-site #:title "IRC" #:part-of 'community]{
@@ -15,9 +15,8 @@
 
 (define irc-content
   @list{Chat in the @tt[style: "background-color: #d8d8e8;"]{@big{@strong{#racket}}} channel on
-@a[href: "https://freenode.net"]{@tt{freenode.net}}, an informal
-discussion channel for all things related to Racket, or
-@a[href: "https://botbot.me/freenode/racket/"]{browse the logs}.})
+@a[href: "https://libera.chat"]{@tt{libera.chat}}, an informal
+discussion channel for all things related to Racket.})
 
 (define irc-quick
   @text{@parlist[@strong{IRC}


### PR DESCRIPTION
Generally point to the community page where possible, otherwise directly to libera.chat. It turns out that botbot.me has gone on an "Our Incredible Journey" by being acquired :roll_eyes: so this removes links to them too.