### PR TITLE
Add link to Racket wiki

### DIFF
--- a/www/index.html.pm
+++ b/www/index.html.pm
@@ -444,6 +444,8 @@ ancestor(A, B)?}}}
 
       ◊link["https://lists.racket-lang.org/"]{Mailing lists} and ◊link["https://blog.racket-lang.org/"]{Blog}
 
+      ◊link["https://github.com/racket/racket/wiki"]{Racket Wiki}
+
       ◊link["https://discord.gg/6Zq8sH5"]{Racket Discord}
 
       ◊link["https://kiwiirc.com/nextclient/irc.libera.chat/#racket"]{#racket IRC} on libera.chat


### PR DESCRIPTION
See https://racket.discourse.group/t/wheres-the-racket-wiki/351

Feel free to put the link at a different position in the list. :-)

As far as I'm concerned, I wanted to leave the "list-ish" links together and the "chat-ish" links, too, so I added the wiki link between these groups. But maybe the links should be reorganized (grouped?) a bit since there are so many already?