### PR TITLE
fix broken licence link to repo

### DIFF
--- a/download/download-pages.rkt
+++ b/download/download-pages.rkt
@@ -465,7 +465,7 @@ var property = null;
        license of that binary.
     @~ Versions of Racket prior to version 7.5 are distributed under the
        GNU LGPL, version 3.0.
-    @~ See the @a[href: "https://github.com/racket/racket/blob/master/LICENSE"]{
+    @~ See the @a[href: "https://github.com/racket/racket/blob/master/LICENSE.txt"]{
        @tt{LICENSE}} file in the source code for more information.
     }}})
 


### PR DESCRIPTION
https://github.com/racket/racket/blob/master/LICENSE returns 404
replaced with 
https://github.com/racket/racket/blob/master/LICENSE.txt