### PR TITLE
"Jet Fueled" -> "Practical"

### DIFF
--- a/www/index.html.pm
+++ b/www/index.html.pm
@@ -59,7 +59,7 @@
   Racket, the Programming Language}}
 ◊div[#:class "frontpage-bar disappearing-late"]{
   ◊button[#:class "frontpage-bar-item frontpage-button unselected-tab langtablink" #:onclick "openTab('the-language',event,'mature','langtablink',true)"]{◊div[#:style "mitem"]{Mature}}
-  ◊button[#:class "frontpage-bar-item frontpage-button unselected-tab langtablink" #:onclick "openTab('the-language',event,'batteries','langtablink',true)"]{◊div[#:style "mitem"]{Jet Fueled}}
+  ◊button[#:class "frontpage-bar-item frontpage-button unselected-tab langtablink" #:onclick "openTab('the-language',event,'batteries','langtablink',true)"]{◊div[#:style "mitem"]{Practical}}
   ◊button[#:class "frontpage-bar-item frontpage-button unselected-tab langtablink" #:onclick "openTab('the-language',event,'extensible','langtablink',true)"]{◊div[#:style "mitem"]{Extensible}}
   ◊button[#:class "frontpage-bar-item frontpage-button unselected-tab langtablink" #:onclick "openTab('the-language',event,'strong','langtablink',true)"]{◊div[#:style "mitem"]{Robust}}
   ◊button[#:class "frontpage-bar-item frontpage-button unselected-tab langtablink" #:onclick "openTab('the-language',event,'drracket','langtablink',true)"]{◊div[#:style "mitem"]{Polished}}


### PR DESCRIPTION
The "Jet Fueled" label doesn't make sense to me, and as a label it seems unlike others (especially if #171 is accepted). I think the panel is about how Racket is "Practical", so I'm proposing that change.