### PR TITLE
remove "DrRacket Tools" link

### DIFF
--- a/www/index.html.pm
+++ b/www/index.html.pm
@@ -150,7 +150,6 @@ Racket comes with support for major editors. The main bundle includes an innovat
                                                             
 ◊doclinks{
 ◊doclink["drracket"]{DrRacket Guide}
-◊doclink["drracket-tools"]{DrRacket Tools}
 ◊link["https://marketplace.visualstudio.com/items?itemName=evzen-wybitul.magic-racket"]{VS Code/Magic Racket}
 ◊link["https://docs.racket-lang.org/guide/Emacs.html"]{Emacs Integration}
 ◊link["https://docs.racket-lang.org/guide/Vim.html"]{Vim Integration}


### PR DESCRIPTION
At Robby's suggestion: remove the "DrRacket Tools" link from the "Polished" panel, mostly because removing it makes the panel like the others, but also because it's more of an internal detail compared to the links on that panel.