### PR TITLE
Fix syntax error in example on the homepage

### DIFF
--- a/www/index.html.pm
+++ b/www/index.html.pm
@@ -76,7 +76,7 @@
        }
       ◊div[#:class "code-to-right-of-big-logo"]{◊langwww["#lang racket/gui"]{
 ◊pre{
-(◊docs{define} my-language 'English)
+(◊docs{define} my-language "English")
 
 (◊docs{define} translations
   #hash([English . "Hello world"]


### PR DESCRIPTION
I think there is a syntax error on the main example on the Racket home page. This PR fixes it.