### PR TITLE
Run GitHub Action in every branch, not just master.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -5,7 +5,6 @@ on: push
 
 jobs:
   coverage:
-    if: github.ref == 'refs/heads/main'
     name: Check whether we can build every site
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
The intent of the "can we build?" GitHub Action was to run it in every branch, not just `master`. The original intent was to allow us to check, before changes get merged into `master`, whether a build will work.