### PR TITLE
Style Racket code blocks used on the blog

### DIFF
--- a/blog/_src/page-template.html
+++ b/blog/_src/page-template.html
@@ -15,6 +15,7 @@
     @(when rel-next @list{<link rel="next" href="@|rel-next|">})
     @(when rel-prev @list{<link rel="prev" href="@|rel-prev|">})
     <!-- CSS -->
+    <link rel="stylesheet" type="text/css" href="@|uri-prefix|/css/scribble.css">
     <link rel="stylesheet" type="text/css" href="@|uri-prefix|/css/main.css">
     <link rel="stylesheet" type="text/css" href="@|uri-prefix|/css/blog-fonts.css">
     <!-- Feeds -->

--- a/blog/css/manual-racket.css
+++ b/blog/css/manual-racket.css
@@ -1,0 +1,327 @@
+/* Copied from Scribble used in Racket 8.7 (e1385468) */
+/* See the beginning of "manual.css". */
+
+/* Monospace: */
+
+.RktIn, .RktRdr, .RktPn, .RktMeta,
+.RktMod, .RktKw, .RktVar, .RktSym,
+.RktRes, .RktOut, .RktCmt, .RktVal,
+.RktBlk, .RktErr {
+  font-family: 'Fira-Mono', monospace;
+  white-space: inherit;
+  font-size: 1rem;
+  line-height: 1.5;
+
+}
+
+/* this selctor grabs the first linked Racket symbol
+in a definition box (i.e., the symbol being defined) */
+a.RktValDef, a.RktStxDef, a.RktSymDef,
+span.RktValDef, span.RktStxDef, span.RktSymDef
+{
+    font-size: 1.1rem;
+    color: black;
+    font-weight: 500;
+}
+
+
+.inheritedlbl {
+  font-family: 'Fira', sans-serif;
+}
+
+.RBackgroundLabelInner {
+  font-family: inherit;
+}
+
+/* ---------------------------------------- */
+/* Inherited methods, left margin */
+
+.inherited {
+  width: 95%;
+  margin-top: 0.5em;
+  text-align: left;
+  background-color: inherit;
+}
+
+.inherited td {
+  font-size: 82%;
+  padding-left: 0.5rem;
+  line-height: 1.3;
+  text-indent: 0;
+  padding-right: 0;
+}
+
+.inheritedlbl {
+  font-style: normal;
+}
+
+/* ---------------------------------------- */
+/* Racket text styles */
+
+.RktIn {
+  color: #cc6633;
+  background-color: #eee;
+  white-space: pre;
+}
+
+.RktInBG {
+  background-color: #eee;
+}
+
+
+.refcolumn .RktInBG {
+  background-color: white;
+}
+
+.RktRdr {
+}
+
+.RktPn {
+  color: #843c24;
+}
+
+.RktMeta {
+  color: black;
+}
+
+.RktMod {
+  color: inherit;
+}
+
+.RktOpt {
+  color: black;
+  font-style: italic;
+}
+
+.RktKw {
+  color: black;
+}
+
+.RktErr {
+  color: red;
+  font-style: italic;
+  font-weight: 400;
+}
+
+.RktVar {
+    position: relative;
+    left: -1px; font-style: italic;
+    color: #444;
+}
+
+.SVInsetFlow .RktVar {
+    font-weight: 400;
+    color: #444;
+}
+
+
+.RktSym {
+   color: inherit;
+}
+
+
+
+.RktValLink, .RktStxLink, .RktModLink {
+  text-decoration: none;
+    color: #07A;
+    font-size: 1rem;
+}
+
+/* for syntax links within headings */
+h2 a.RktStxLink, h3 a.RktStxLink, h4 a.RktStxLink, h5 a.RktStxLink,
+h2 a.RktValLink, h3 a.RktValLink, h4 a.RktValLink, h5 a.RktValLink,
+h2 .RktSym, h3 .RktSym, h4 .RktSym, h5 .RktSym,
+h2 .RktMod, h3 .RktMod, h4 .RktMod, h5 .RktMod,
+h2 .RktVal, h3 .RktVal, h4 .RktVal, h5 .RktVal,
+h2 .RktPn, h3 .RktPn, h4 .RktPn, h5 .RktPn {
+    color: #333;
+    font-size: 1.50rem;
+    font-weight: 400;
+}
+
+.toptoclink .RktStxLink, .toclink .RktStxLink,
+.toptoclink .RktValLink, .toclink .RktValLink,
+.toptoclink .RktModLink, .toclink .RktModLink {
+    color: inherit;
+}
+
+.tocset .RktValLink, .tocset .RktStxLink, .tocset .RktModLink, .tocset .RktSym {
+    color: black;
+    font-weight: 400;
+    font-size: 0.9rem;
+}
+
+.tocset td a.tocviewselflink .RktValLink,
+.tocset td a.tocviewselflink .RktStxLink,
+.tocset td a.tocviewselflink .RktMod,
+.tocset td a.tocviewselflink .RktSym {
+    font-weight: lighter;
+    color: white;
+}
+
+
+.RktRes {
+  color: #0000af;
+}
+
+.RktOut {
+  color: #960096;
+}
+
+.RktCmt {
+  color: #c2741f;
+}
+
+.RktVal {
+  color: #228b22;
+}
+
+/* ---------------------------------------- */
+/* Some inline styles */
+
+.together { /* for definitions grouped together in one box */
+  width: 100%;
+  border-top: 2px solid white;
+}
+
+tbody > tr:first-child > td > .together {
+  border-top: 0px; /* erase border on first instance of together */
+}
+
+.RktBlk {
+  white-space: pre;
+  text-align: left;
+}
+
+.highlighted {
+    font-size: 1rem;
+    background-color: #fee;
+}
+
+.defmodule {
+    font-family: 'Fira-Mono', monospace;
+    padding: 0.25rem 0.75rem 0.25rem 0.5rem;
+    margin-bottom: 1rem;
+    width: 100%;
+    background-color: #ebf0f4;
+}
+
+.defmodule a {
+    color: #444;
+}
+
+
+.defmodule td span.hspace:first-child {
+  position: absolute;
+  width: 0;
+  display: inline-block;
+}
+
+.defmodule .RpackageSpec .Smaller,
+.defmodule .RpackageSpec .stt {
+    font-size: 1rem;
+}
+
+/* make parens ordinary color in defmodule */
+.defmodule .RktPn {
+    color: inherit;
+}
+
+.specgrammar {
+    float: none;
+    padding-left: 1em;
+}
+
+
+.RBibliography td {
+  vertical-align: text-top;
+  padding-top: 1em;
+}
+
+.leftindent {
+ margin-left: 2rem;
+ margin-right: 0em;
+}
+
+.insetpara {
+ margin-left: 1em;
+ margin-right: 1em;
+}
+
+.SCodeFlow .Rfilebox {
+    margin-left: -1em; /* see 17.2 of guide, module languages */
+}
+
+.Rfiletitle {
+  text-align: right;
+  background-color: #eee;
+}
+
+.SCodeFlow .Rfiletitle {
+  border-top: 1px dotted gray;
+  border-right: 1px dotted gray;
+}
+
+
+.Rfilename {
+  border-top: 0;
+  border-right: 0;
+  padding-left: 0.5em;
+  padding-right: 0.5em;
+  background-color: inherit;
+}
+
+.Rfilecontent {
+  margin: 0.5em;
+}
+
+.RpackageSpec {
+  padding-right: 0;
+}
+
+/* ---------------------------------------- */
+/* For background labels */
+
+.RBackgroundLabel {
+   float: right;
+   width: 0px;
+   height: 0px;
+}
+
+.RBackgroundLabelInner {
+   position: relative;
+   width: 25em;
+   left: -25.5em;
+   top: 0.20rem; /* sensitive to monospaced font choice */
+   text-align: right;
+   z-index: 0;
+   font-weight: 300;
+   font-family: 'Fira-Mono', monospace;
+   font-size: 0.9rem;
+    color: gray;
+}
+
+
+.RpackageSpec .Smaller {
+   font-weight: 300;
+   font-family: 'Fira-Mono', monospace;
+   font-size: 0.9rem;
+}
+
+.RForeground {
+   position: relative;
+   left: 0px;
+   top: 0px;
+   z-index: 1;
+}
+
+/* ---------------------------------------- */
+/* For section source modules & tags */
+
+.RPartExplain {
+    background: #eee;
+    font-size: 0.9rem;
+    margin-top: 0.2rem;
+    padding: 0.2rem;
+    text-align: left;
+}

--- a/blog/css/scribble.css
+++ b/blog/css/scribble.css
@@ -1,0 +1,19 @@
+@import url("manual-racket.css");
+
+.SCodeFlow {
+  border-left: 1px dotted black;
+  padding-left: 1em;
+  padding-right: 1em;
+  margin-bottom: 1em;
+  margin-right: 2em;
+  white-space: nowrap;
+  line-height: 1.5;
+}
+
+.SCodeFlow p {
+  margin-bottom: 0;
+}
+
+.RktBlk {
+  white-space: nowrap;
+}


### PR DESCRIPTION
This copies in the essential styles from Scribble to present Racket code blocks with nice formatting on the blog. In particular, this ensures they are shown with monospaced fonts and use the font colours from the documentation.

The styles added here are deliberately kept minimal to avoid changing the blog's overall look and feel outside of Racket code blocks.

![image](https://user-images.githubusercontent.com/279572/204608017-732ffc00-ee83-4a8f-a548-9ae6363f81ed.png)

Fixes https://github.com/racket/racket-lang-org/issues/228

cc @samth @bennn 