### PR TITLE
feat: support python3

### DIFF
--- a/blog/all.rkt
+++ b/blog/all.rkt
@@ -4,6 +4,7 @@
          racket/path
          racket/system
          raco/all-tools
+         "python.rkt"
          "../identity.rkt"
          "../testing.rkt")
 
@@ -15,7 +16,8 @@
 (define-runtime-path blog-dir ".")
 (define css-dir (simplify-path (build-path blog-dir "css/")))
 
-(unless (system "python -c 'import pygments'")
+
+(unless (system* python-executable "-c" "import pygments")
   (error 'python "pygments required to preserve doc links for code on the blog"))
 
 (define v (all-tools))

--- a/blog/frog.rkt
+++ b/blog/frog.rkt
@@ -1,5 +1,7 @@
 #lang frog/config
 
+(require "python.rkt")
+
 ;; Called early when Frog launches. Use this to set parameters defined
 ;; in frog/params.
 (define/contract (init)
@@ -28,7 +30,7 @@
   (-> (listof xexpr/c) (listof xexpr/c))
   ;; Here we pass the xexprs through a series of functions.
   (~> xs
-      (syntax-highlight #:python-executable "python"
+      (syntax-highlight #:python-executable python-executable
                         #:line-numbers? #f
                         #:css-class "pygments")
       (auto-embed-tweets #:parents? #t)

--- a/blog/python.rkt
+++ b/blog/python.rkt
@@ -1,0 +1,8 @@
+#lang racket/base
+
+(provide python-executable)
+
+(define python-executable
+  (or (find-executable-path "python")
+      (find-executable-path "python3")
+      (error 'python "cannot find python executable")))


### PR DESCRIPTION
This commit adds a support for Python 3 by looking for `python3` in case the `python` executable can't be found.