### PR TITLE
chore: add /Web to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,5 @@ school/2019/*.css
 school/2020/*.html
 school/2020/*.css
 school/2020/*.js
+
+/Web


### PR DESCRIPTION
`Web` is the recommended build target in the README, but it should not be committed to the repo.