### PR TITLE
feat: make it possible to link to a tab

### DIFF
--- a/www/community.html
+++ b/www/community.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<html>
+    <head>
+        <meta http-equiv="refresh" content="0; url=index.html#community" />
+    </head>
+    <body>
+    </body>
+</html>

--- a/www/index.html.pm
+++ b/www/index.html.pm
@@ -410,4 +410,20 @@ for their generous support over the years.}}
 ◊script[#:src "js/jquery.min.js"]{}
 
 ◊script{
+document.addEventListener('DOMContentLoaded', () => {
+  if (window.location.hash) {
+    const anchor = window.location.hash.substring(1);
+    const elem = document.getElementById(anchor);
+    if (elem) {
+      elem.checked = true;
+      document.querySelector(`#${anchor} + label + div.tab`).scrollIntoView();
+    }
+  }
+  const btnOnClick = e => {
+    window.location.href = '#' + e.target.id;
+  };
+  document.querySelectorAll('.btn-link').forEach(btn => {
+    btn.addEventListener('click', btnOnClick);
+  });
+});
 }

--- a/www/index.rkt
+++ b/www/index.rkt
@@ -43,10 +43,6 @@
   (define relpath (find-relative-path (simplify-path www-dir) (simplify-path path)))
   (copyfile #:site www-2016-site path (path->string relpath)))
 
-;; make some old pages redirect to the main page
-(void (symlink #:site www-2016-site "index.html" "community.html"))
-(void (symlink #:site www-2016-site "index.html" "irc-chat.html"))
-
 (module+ test
   (module config info
     (define ignore-stderr "pollen: ")))

--- a/www/irc-chat.html
+++ b/www/irc-chat.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<html>
+    <head>
+        <meta http-equiv="refresh" content="0; url=index.html#community" />
+    </head>
+    <body>
+    </body>
+</html>


### PR DESCRIPTION
This commit makes it possible to link to a tab. For example,
https://www.racket-lang.oth/#ide-support would link to the "IDE support" tab.
Each tab change will modify the URL so that viewers can copy the link.

Furthermore, remove the symlinks community.html and irc-chat.html,
and make them redirect to the `#community` tab.

The commit depends on #254.

Fixes #209