### PR TITLE
RacketCon'23: a livestream and chat iframes

### DIFF
--- a/rcon/2023/index.rkt
+++ b/rcon/2023/index.rkt
@@ -293,11 +293,12 @@ $(document).ready(function () {
 <iframe width="720" height="410" src="https://boxcast.tv/view-embed/xtihxdvdmgttkttsp2gj?showTitle=0&showDescription=0&showHighlights=0&showRelated=0&defaultVideo=next&market=smb&showDocuments=0&showIndex=0&showDonations=0" frameBorder="0" scrolling="auto" allowfullscreen="true" allow="autoplay; fullscreen"></iframe>
 --
          )
-
+#|
   (cdata #f #f #<<--
 <iframe src="https://www6.cbox.ws/box/?boxid=846185&boxtag=7afys&tid=127&tkey=b25da2af9627c97d" width="100%" height="450" allowtransparency="yes" allow="autoplay" frameborder="0" marginheight="0" marginwidth="0" scrolling="auto"></iframe>
 --
-         ))
+         )
+|#)
 
  (section
   @sectionHeader{Saturday, October 28th}

--- a/rcon/2023/index.rkt
+++ b/rcon/2023/index.rkt
@@ -287,6 +287,17 @@ $(document).ready(function () {
 (txexpr* 'time `((class "dt-end") (hidden "") (datetime ,(gregor:~t sunday "y-MM-dd"))))
 
 (column
+ (section
+  @sectionHeader{Live Stream}
+  (cdata #f #f #<<--
+<iframe width="720" height="410" src="https://boxcast.tv/view-embed/xtihxdvdmgttkttsp2gj?showTitle=0&showDescription=0&showHighlights=0&showRelated=0&defaultVideo=next&market=smb&showDocuments=0&showIndex=0&showDonations=0" frameBorder="0" scrolling="auto" allowfullscreen="true" allow="autoplay; fullscreen"></iframe>
+--
+         )
+
+  (cdata #f #f #<<--
+<iframe src="https://www6.cbox.ws/box/?boxid=846185&boxtag=7afys&tid=127&tkey=b25da2af9627c97d" width="100%" height="450" allowtransparency="yes" allow="autoplay" frameborder="0" marginheight="0" marginwidth="0" scrolling="auto"></iframe>
+--
+         ))
 
  (section
   @sectionHeader{Saturday, October 28th}


### PR DESCRIPTION
I'm not sure if this is the best way to put the livestream. Right now it is at the top of the page, looking something like this:

<img width="481" alt="Screenshot 2023-10-12 at 7 46 46 PM" src="https://github.com/racket/racket-lang-org/assets/399024/08b1d1d9-784c-4f5f-a5d4-2107b7d06f98">
