### PR TITLE
Add missing blurbs for RacketCon talks

### DIFF
--- a/rcon/2023/index.rkt
+++ b/rcon/2023/index.rkt
@@ -573,6 +573,10 @@ My first Typed Racket program was an interpreter for the Lox language from Bob N
 #:link "https://youtu.be/OLgEL4esYU0"
 #:what
 @talk{Rhombus: Status Update}
+#:more
+@abstract{
+This talk demonstrates the current version of Rhombus, which is a new programming language that seamlessly integrates Racket's powerful macro system with a conventional infix syntax. Rhombus's goal is to make Racket's macro capabilities more accessible: through the use of conventional syntax, by unifying more programming and metaprogramming constructs (e.g., using `match` for data and for code), and by packaging common patterns for macro primitives into out-of-the-box coordination facilities (e.g., macro-extensible binding positions).  Through live coding on example programs, the talk demonstrates how Rhombus features work together to define a convenient and expressive programming language.
+}
 ]
 
   @coffee[@talk-time{Sunday, 10:30am}]

--- a/rcon/2023/index.rkt
+++ b/rcon/2023/index.rkt
@@ -592,6 +592,16 @@ This talk demonstrates the current version of Rhombus, which is a new programmin
 #:link "https://youtu.be/fN_7LFg_7r8"
 #:what
 @talk{The State of Racket}
+#:more
+@abstract{
+Join Sam Tobin-Hochstadt for an informative and insightful overview of the latest developments in the Racket language and community. This annual address covers key advancements, milestones, and community contributions achieved over the past year, providing a comprehensive update on the language's growth, direction, and impact.
+
+Learn about the latest improvements to Typed Racket, including shallow and optional types, as well as the integration of Racket's Chez Scheme fork upstream, a significant culmination of years of collaboration. Explore the contributions of the community, including big improvements in Racket Mode for Emacs and the r16 trick bot for Discord, and much more.
+
+Sam also provides a glimpse into the future of Racket, teasing upcoming releases and innovations that are on the horizon, providing insights into the community's roadmap which includes type inference, compiling Racket to web, and enhanced tooling further streamlining the process of finding and installing Racket packages.
+
+Whether you're a seasoned Racket developer or a newcomer to the language, don't miss this opportunity to learn about the latest developments in Racket and get a sneak peek at its future!
+}
 ]
 
   @lecture[

--- a/rcon/2023/index.rkt
+++ b/rcon/2023/index.rkt
@@ -198,6 +198,7 @@
                  #:link [l #f]
                  #:what [what ""]
                  #:more [more ""]
+                 #:even-more [even-more ""]
                  #:bio [bio #f]
                  #:first? [first? #f])
   ((if first? first-speech speech) when
@@ -207,6 +208,7 @@
                                        "")
                                    what
                                    more
+                                   even-more
                                    (or bio "")))
 
 (define (hallway when)
@@ -222,9 +224,10 @@
 (define (lunch when)
  (lecture #:when when #:who @speaker[#:person? #f]{@bold{Lunch}}))
 
-(define (keynote when #:who who #:what what #:link [link #f])
+(define (keynote when #:who who #:what what #:more more #:link [link #f])
   (lecture #:when when #:who @speaker[#:person? #f]{@bold{Keynote}}
-           #:what (keynote-speaker who) #:link link #:more what))
+           #:what (keynote-speaker who) #:link link #:more what
+           #:even-more more))
 
 (define (bio . contents)
  (apply bio-div @bio-label{Bio: } contents))

--- a/rcon/2023/index.rkt
+++ b/rcon/2023/index.rkt
@@ -326,6 +326,16 @@ $(document).ready(function () {
 #:link "https://youtu.be/vMDHpPN_p08"
 #:what
 @talk{From Here To Lambda And Back Again}
+#:more
+@abstract{
+@para{Renowned computer scientist Douglas Crockford delivers a thought-provoking keynote address at RacketCon 2023, tracing the evolution of programming language paradigms and presenting a compelling argument for the resurgence of the actor model, a paradigm that emerged in the 1970s.}
+
+@para{Crockford, a renowned expert in programming language design and implementation, guides the audience on a captivating journey through the history of programming paradigms, highlighting their strengths, limitations, and impact on the field. He astutely observes the recurring cycles of paradigm popularity, with each new paradigm promising to revolutionize software development only to eventually be overtaken by the next, and often for reasons more to do with inertia than merit.}
+
+@para{In a bold and insightful prediction, Crockford asserts that the actor model, once considered a niche paradigm, is poised to reclaim its prominence in the future of programming. He eloquently explains how the actor model's inherent concurrency and message-passing capabilities align perfectly with the demands of modern distributed and cloud-based computing environments.}
+
+@para{Crockford's insights serve as a timely reminder of the importance of revisiting and reappraising past paradigms to uncover hidden potential and adapt to the ever-changing landscape of software development.}
+}
 ]
 
   @coffee[@talk-time{Saturday, 10:00am}]


### PR DESCRIPTION
This was initially added on the YouTube video to match the other talks which have descriptions and help people discover the content. @jryans suggested also adding it to the site here.

We're adding blurbs for:

- Douglas's keynote
- Matthew's talk on Rhombus
- Sam's State of Racket
