### PR TITLE
switch Mac download default to Apple Silicon

### DIFF
--- a/download/download-pages.rkt
+++ b/download/download-pages.rkt
@@ -556,8 +556,8 @@ var property = null;
       else if (l("WOW64")) return [Win64, Win];
       else if (l("Win"))   return [Win32, Win];
       else if (l("Mac"))   return [
-        l("Intel") ? MacIntel64 : MacPPC,
         l("Intel") ? MacARM64 : MacPPC,
+        l("Intel") ? MacIntel64 : MacPPC,
         l("Intel") ? MacIntel32 : MacPPC,
         Mac,
         Unix
@@ -782,8 +782,8 @@ var property = null;
 
       @(if (version<=? version-before-m1-support version)
            @list{
-                 showWhen('m1_mac_explain', platform === 'x86_64-macosx');
-                 @; showWhen('intel_mac_explain', platform === 'aarch64-macosx');
+                 @; showWhen('m1_mac_explain', platform === 'x86_64-macosx');
+                 showWhen('intel_mac_explain', platform === 'aarch64-macosx');
            }
            null)
 


### PR DESCRIPTION
Continuing from #291. The initial commit here just swaps the default from Intel to Apple Silicon, and it shows an alert for "Intel Mac users" when Apple Silicon is selected (side-stepping the question of whether to mention M1, etc.).

See #291 for JavaScript strategies to try to pick the variant that matches a user's machine. I haven't tried to incorporate that here, because it seems too complex and fragile to me, but I don't object if someone else wants to add to this PR.