### PR TITLE
Avoid recommending outdated PPA for now

### DIFF
--- a/download/download-pages.rkt
+++ b/download/download-pages.rkt
@@ -76,9 +76,9 @@
                              "Download")]
       @br
       or @a[href: (resource "download/" #f) id: "mirror_link"]{mirror}
-      @span[id: "linux_ppa"]{
+      @;{span[id: "linux_ppa"]{
         or
-        @a[href: "https://launchpad.net/~plt/+archive/ubuntu/racket"]{Ubuntu PPA}}
+        @a[href: "https://launchpad.net/~plt/+archive/ubuntu/racket"]{Ubuntu PPA}}}
       @span[id: "linux_flatpak"]{
         or
         @a[href: "https://flathub.org/apps/details/org.racket_lang.Racket"]{


### PR DESCRIPTION
While [replying to a Discourse post](https://racket.discourse.group/t/flomat-install-under-linux-can-not-find-libfortran/3088/13), I noticed that the Ubuntu PPA is still on Racket 8.6. Meanwhile, Ubuntu [23.10 (Mantic Minotaur)](https://packages.ubuntu.com/mantic/racket) has Racket 8.7, Ubuntu [24.04 LTS (Noble Numbat)](https://packages.ubuntu.com/noble/racket) has Racket 8.10, and the forthcoming [24.10 (Oracular Oriole)](https://packages.ubuntu.com/oracular/racket) currently has Racket 8.12. ([Debian Testing](https://packages.debian.org/trixie/racket) has Racket 8.13, so Ubuntu could pull further updates before their release.) The Ubuntu 24.04.1 LTS point release is scheduled for this month, at which point Ubuntu will begin prompting users of 22.04 LTS (Jammy Jellyfish) to upgrade.

Since even users following LTS Ubuntu will get a newer version of Racket from the distro apt repository than by using the PPA, I think it would be confusing to continue recommending the PPA until it is updated. I haven't tested this, but, depending on what apt configuration PPAs generate, I'm concerned that enabling the PPA might even hide the newer Racket available from the distro repository.