### PR TITLE
Create 2025-01-31-racket-v8-16.md

### DIFF
--- a/blog/_src/posts/2025-01-31-racket-v8-16.md
+++ b/blog/_src/posts/2025-01-31-racket-v8-16.md
@@ -1,0 +1,46 @@
+    Title: Racket v8.16
+    Date: 2025-01-31T13:12:00
+    Tags: release-announcement, DRAFT
+    Authors: John Clements, Stephen De Gabrielle
+
+
+*posted by Stephen De Gabrielle*
+
+----------------------------------------------------------------------
+
+We are pleased to announce Racket v8.16 is now available from [https://download.racket-lang.org/](https://download.racket-lang.org).
+
+## As of this release:
+
+- Single line.
+
+- Paragraph paragraph paragraph paragraph paragraph paragraph paragraph 
+  paragraph paragraph paragraph paragraph paragraph paragraph paragraph
+  paragraph.  ([link text](https://docs.racket-lang.org/links-to-thing))
+
+## Thank you
+
+The following people contributed to this release:
+
+.
+
+_Racket is a community developed open source project and we welcome new
+contributors. See 
+[racket/README.md](https://github.com/racket/racket/blob/master/README.md#contributing)
+to learn how you can be a part of this amazing project._
+
+## Feedback Welcome
+
+Questions and discussion welcome at the Racket community
+[Discourse](https://racket.discourse.group/invites/VxkBcXY7yL) or
+[Discord](https://discord.gg/6Zq8sH5) 
+
+## Please share
+
+If you can  - please help get the word out to users and platform specific repo packagers
+
+```
+Racket - the Language-Oriented Programming Language - version 8.16 is now available from https://download.racket-lang.org
+
+See https://blog.racket-lang.org/2024/08/racket-v8-16.html for the release announcement and highlights.
+```


### PR DESCRIPTION
@jbclements is this right?

> After this is done, the release manager changes the DRAFT tag into the release-management tag, to allow simultaneous release of the blog post and the download link.

from wiki https://github.com/racket/racket/wiki/Release-process#instructions-for-communications-manager-and-community-liaison