### PR TITLE
Update 2025-01-31-racket-v8-16.md

### DIFF
--- a/blog/_src/posts/2025-01-31-racket-v8-16.md
+++ b/blog/_src/posts/2025-01-31-racket-v8-16.md
@@ -12,11 +12,62 @@ We are pleased to announce Racket v8.16 is now available from [https://download.
 
 ## As of this release:
 
-- Single line.
+- Expanded support for immutable and mutable treelists
+  - A variety of new treelist utility functions are available:
+  [`treelist-filter`](https://pre-release.racket-lang.org/doc/reference/treelist.html#%28def._%28%28lib._racket%2Ftreelist..rkt%29._treelist-filter%29%29), [`treelist-flatten`](https://pre-release.racket-lang.org/doc/reference/treelist.html#%28def._%28%28lib._racket%2Ftreelist..rkt%29._treelist-flatten%29%29), et cetera.
+  - The [`mutable-treelist-prepend!`](https://pre-release.racket-lang.org/doc/reference/treelist.html#%28def._%28%28lib._racket%2Fmutable-treelist..rkt%29._mutable-treelist-prepend%21%29%29) function allows prepending to mutable treelists.
+  - [Mutable treelists](https://pre-release.racket-lang.org/doc/reference/treelist.html#%28part._.Mutable_.Treelists%29) are [serializable](https://pre-release.racket-lang.org/doc/reference/serialization.html). 
 
-- Paragraph paragraph paragraph paragraph paragraph paragraph paragraph 
-  paragraph paragraph paragraph paragraph paragraph paragraph paragraph
-  paragraph.  ([link text](https://docs.racket-lang.org/links-to-thing))
+- The [`serialize-structs`](https://pre-release.racket-lang.org/doc/reference/serialization.html#%28mod-path._racket%2Fserialize-structs%29) module allows the minimization of
+  dependencies by providing only a handful of core forms
+- The [`flbit-field`](https://pre-release.racket-lang.org/doc/reference/flonums.html#%28def._%28%28lib._racket%2Fflonum..rkt%29._flbit-field%29%29) function allows access to the binary
+  representation of IEEE floating-point numbers.
+- The top-left search box in the [documentation](https://pre-release.racket-lang.org/doc/index.html) works once more.
+- The [XML reader](https://pre-release.racket-lang.org/doc/xml/index.html#%28part._.Reading_and_.Writing_.X.M.L%29) is 2-3x faster on inputs with long CDATA 
+  and comments, and avoids some internal contract checks to
+ obtain a 25% speedup on large documents generally.
+- The [pregexp syntax includes "\X" to match a grapheme cluster](https://pre-release.racket-lang.org/doc/reference/regexp.html#(part._regexp-syntax)),
+  following Perl and PCRE.
+- The [`read-json*`](https://pre-release.racket-lang.org/doc/json/index.html#%28def._%28%28submod._%28lib._json%2Fmain..rkt%29._for-extension%29._read-json%2A%29%29) and [`write-json*`](https://pre-release.racket-lang.org/doc/json/index.html#%28def._%28%28submod._%28lib._json%2Fmain..rkt%29._for-extension%29._write-json%2A%29%29) functions allow customization of
+  the Racket representation of JSON elements, eliminating the need for
+  a separate "translation" pass.
+  
+- New port I/O functions
+  - The [`open-input-nowhere`](https://pre-release.racket-lang.org/doc/reference/port-lib.html#%28def._%28%28lib._racket%2Fport..rkt%29._open-input-nowhere%29%29) function creates an empty input port.
+  - The [`pipe-port?`](https://pre-release.racket-lang.org/doc/reference/pipeports.html#%28def._%28%28quote._~23~25kernel%29._pipe-port~3f%29%29) function makes it possible to determine whether a
+  port is created by [`make-pipe`](https://pre-release.racket-lang.org/doc/reference/pipeports.html#%28def._%28%28quote._~23~25kernel%29._make-pipe%29%29).
+  - The [`port-file-stat`](https://pre-release.racket-lang.org/doc/reference/file-ports.html#%28def._%28%28quote._~23~25kernel%29._port-file-stat%29%29) function allows gathering information about the
+  file that is the source or target of a file-stream port.
+
+- A revised representation of pointers improves the performance of foreign
+function calls.
+   - [`ptr-ref`](https://pre-release.racket-lang.org/doc/foreign/foreign_pointer-funcs.html#%28def._%28%28quote._~23~25foreign%29._ptr-ref%29%29) and [`ptr-set!`](https://pre-release.racket-lang.org/doc/foreign/foreign_pointer-funcs.html#%28def._%28%28quote._~23~25foreign%29._ptr-set%21%29%29) are substantially faster.
+  - [Details the FFI improvement (with some benchmarking results)](https://racket.discourse.group/t/fixnum-slow-despite-docs/3409/6)
+
+- In anticipation of the fifteenth [RacketCon](https://con.racket-lang.org), the [`fifteenth`](https://pre-release.racket-lang.org/doc/reference/pairs.html#%28def._%28%28lib._racket%2Flist..rkt%29._fifteenth%29%29) function
+  returns the fifteenth element of a list.
+- Racket has an improved multi-line convention for error messages.
+- The [`db` library](https://pre-release.racket-lang.org/doc/db/index.html) allows [`prepare`](https://pre-release.racket-lang.org/doc/db/query-api.html#%28def._%28%28lib._db%2Fbase..rkt%29._prepare%29%29) on virtual statements.
+- The [`student-t` distribution](https://pre-release.racket-lang.org/doc/math/Real_Distribution_Families.html#%28part._.Student-t_.Distributions%29) is part of the [`math/distributions` library](https://pre-release.racket-lang.org/doc/math/dist.html).
+- [Expeditor](https://pre-release.racket-lang.org/doc/expeditor/index.html) supports customizing the prompt, using the [`prompt`
+  argument to `call-with-expeditor`](https://pre-release.racket-lang.org/doc/expeditor/Expeditor_API.html#%28def._%28%28lib._expeditor%2Fmain..rkt%29._call-with-expeditor%29%29).
+- There is a [guide to adding internationalization for a new (human)
+  language.](https://racket.discourse.group/t/advent-2024-day-translate-drracket-interface-in-your-language/3407)
+- `#lang htdp/asl` incorporates [Graphical Debugger](https://docs.racket-lang.org/drracket/debugger.html#%28part._.Debugger_.Buttons%29) support.
+- There is lots of new documentation, and many defects repaired!
+
+The following people contributed to this release:
+
+a11ce, Alex Knauth, Alexander Shopov, Alexis King, Andrew
+Mauer-Oats, Anthony Carrico, Bert De Ketelaere, Bob Burger, Bogdan
+Popa, D. Ben Knoble, David Van Horn, Gustavo Massaccesi, halfminami,
+Hao Zhang, Jacqueline Firth, Jinser Kafka, JJ, John Clements, Jörgen
+Brandt, Kraskaska, lafirest, Laurent Orseau, lukejianu, Marc
+Nieper-Wißkirchen, Matthew Flatt, Matthias Felleisen, mehbark, Mike
+Sperber, Noah Ma, Onorio Catenacci, Oscar Waddell, Pavel Panchekha,
+payneca, Robby Findler, Sam Phillips, Sam Tobin-Hochstadt, Shu-Hung
+You, Sorawee Porncharoenwase, Stephen De Gabrielle, Wing Hei Chan,
+Yi Cao, and ZhangHao.
 
 ## Thank you
 


### PR DESCRIPTION
added links to pre-release.racket-lang.org/doc

I believe a simple substitution give the correct address once live

  `pre-release.racket-lang.org/doc`==>`docs.racket-lang.org/doc`

Soft-wrap FTW