### PR TITLE
Don't redirect 2024 to the new homepage for 2025

### DIFF
--- a/sync.rkt
+++ b/sync.rkt
@@ -132,7 +132,7 @@
   (add-routing-rules "con.racket-lang.org"
                      #:preserve-existing? #f ; so redirect for old year is dropped
                      (list
-                      (redirect-prefix-routing-rule #:old-prefix "2024/"
+                      (redirect-prefix-routing-rule #:old-prefix "2025/"
                                                     #:new-prefix ""
                                                     #:redirect-code "302"))
                      #:log-info displayln)


### PR DESCRIPTION
The 2024 page redirects to the 2025 page at the moment and so is inaccessible:

https://con.racket-lang.org/2024

This appears to be the fix, going by last year's changes.
