### PR TITLE
Fix typo in Rhombus 1.0 announcement

### DIFF
--- a/blog/_src/posts/2026-06-22-rhombus-v1.0.md
+++ b/blog/_src/posts/2026-06-22-rhombus-v1.0.md
@@ -28,7 +28,7 @@ Søgaard, and Sam Tobin-Hochstadt.
 Rhombus Goals
 -------------
 
-Modern programming languages reflect a consensus on the the most
+Modern programming languages reflect a consensus on the most
 important programming concepts, including lexically scoped variables,
 closures, objects, pattern matching, and type parametricity. Why,
 then, yet another programming language?


### PR DESCRIPTION
I'm not sure if typos in the blog post are fixed, but in case they are fixed, I remove a duplicated "the".

